### PR TITLE
Jenkins ECS agent plugin fixes

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -151,6 +151,17 @@ public class ECSCloud extends Cloud {
         return tunnel;
     }
 
+    public String getCloudWatchAlarmName() {
+        return cloudWatchAlarmName;
+    }
+
+    public String getInstanceCapStr() {
+        if (instanceCap == Integer.MAX_VALUE)
+            return "";
+        else
+            return String.valueOf(instanceCap);
+    }
+
     @DataBoundSetter
     public void setTunnel(String tunnel) {
         this.tunnel = tunnel;

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSComputer.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSComputer.java
@@ -75,10 +75,21 @@ public class ECSComputer extends AbstractCloudComputer<ECSSlave> {
     private void terminate() {
         isAcceptingTasks = false;
 
-        try {
-            getNode().terminate();
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Error while terminating ECS task: ", e);
-        }
+        threadPoolForRemoting.submit(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(20000);
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                }
+
+                try {
+                    getNode().terminate();
+                } catch (Exception e) {
+                    LOGGER.log(Level.WARNING, "Error while terminating ECS task: ", e);
+                }
+            }
+        });
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlave.java
@@ -34,16 +34,20 @@ import hudson.slaves.CloudRetentionStrategy;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.RetentionStrategy;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Collections;
+import jenkins.model.Jenkins;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class ECSSlave extends AbstractCloudSlave {
+    private static final Logger LOGGER = Logger.getLogger(ECSSlave.class.getName());
 
     @Nonnull
     private final ECSCloud cloud;
@@ -99,7 +103,11 @@ public class ECSSlave extends AbstractCloudSlave {
     @Override
     protected void _terminate(TaskListener listener) throws IOException, InterruptedException {
         if (taskArn != null) {
-            cloud.deleteTask(taskArn, clusterArn);
+            try {
+                cloud.deleteTask(taskArn, clusterArn);
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, "Error while deleting task: " + taskArn, e);
+            }
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate.java
@@ -39,6 +39,7 @@ import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.model.Label;
+import hudson.model.Node;
 import hudson.model.labels.LabelAtom;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -68,6 +69,8 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
      */
     @CheckForNull
     private final String label;
+
+    public final Node.Mode mode;
     /**
      * Docker image
      * @see ContainerDefinition#withImage(String)
@@ -148,6 +151,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
 
     @DataBoundConstructor
     public ECSTaskTemplate(@Nullable String label,
+                           Node.Mode mode,
                            @Nonnull String image,
                            @Nullable String remoteFSRoot,
                            int memory,
@@ -158,6 +162,7 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
                            @Nullable List<ExtraHostEntry> extraHosts,
                            @Nullable List<MountPointEntry> mountPoints) {
         this.label = label;
+        this.mode = mode;
         this.image = image;
         this.remoteFSRoot = remoteFSRoot;
         this.memory = memory;
@@ -186,6 +191,10 @@ public class ECSTaskTemplate extends AbstractDescribableImpl<ECSTaskTemplate> {
 
     public String getLabel() {
         return label;
+    }
+
+    public Node.Mode getMode() {
+        return mode;
     }
 
     public String getImage() {

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
@@ -48,6 +48,9 @@
     <f:entry field="cloudWatchAlarmName" title="${%CloudWatch Alarm Name}" >
       <f:textbox />
     </f:entry>
+    <f:entry title="${%Instance Cap}" field="instanceCapStr">
+      <f:textbox />
+    </f:entry>
 
   </f:advanced>
 

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/config.jelly
@@ -49,7 +49,7 @@
       <f:textbox />
     </f:entry>
     <f:entry title="${%Instance Cap}" field="instanceCapStr">
-      <f:textbox />
+      <f:number clazz="positive-number" />
     </f:entry>
 
   </f:advanced>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/help-instanceCapStr.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud/help-instanceCapStr.html
@@ -1,0 +1,35 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<div>
+    You can place the upward limit to the number of ECS tasks that Jenkins may launch.
+
+    <P>
+    For example, if this field is 3, Jenkins will only launch a new task
+    as long as total number of tasks you run on ECS doesn't exceed this number. In this way,
+    even in the worst case of Jenkins starting tasks and forgetting about them,
+    you have an upper bound in the number of tasks that are concurrently executed.
+
+    <p>
+    Leave this field empty to remove a cap
+</div>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -36,10 +36,10 @@
     <f:textbox default="/home/jenkins" />
   </f:entry>
   <f:entry title="${%Memory (Mb)}" field="memory">
-    <f:textbox />
+    <f:number clazz="required positive-number" default="512" />
   </f:entry>
   <f:entry title="${%CPU units}" field="cpu">
-    <f:textbox default="1"/>
+    <f:number clazz="required positive-number" default="1"/>
   </f:entry>
   <f:advanced>
     <f:entry title="${%Override entrypoint}" field="entrypoint">

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -28,6 +28,7 @@
   <f:entry title="Label" field="label">
     <f:textbox />
   </f:entry>
+  <f:slave-mode name="mode" node="${instance}" />
   <f:entry title="${%Docker Image}" field="image">
     <f:textbox default="jenkinsci/jnlp-slave" />
   </f:entry>


### PR DESCRIPTION
Added an instance cap: Allows us to control the maximum number of tasks which can be triggered
Added sleep to node termination: Prevents a race inside of Jenkins which could cause the node to be re-added if the build completes before Jenkins has registered the node as active
Added mode to task template: this allows us to define that a build MUST have the label specified in the template to trigger on ECS. This will allow us to roll out this functionality slowly to our Jenkins server.
